### PR TITLE
Removed duplicate item in process core definition

### DIFF
--- a/doc/source/process/CoreDefinition.rst
+++ b/doc/source/process/CoreDefinition.rst
@@ -76,13 +76,10 @@ Principles
    2. You are not OpenStack, if you pass all the tests but do not use the
       API framework
 
-   3. You are not OpenStack, if you pass all the tests but do not use the
-      API framework
-
-   4. This also surfaces bit-rot in alternate implementations to the larger
+   3. This also surfaces bit-rot in alternate implementations to the larger
       community
 
-   5. This behavior improves interoperability because there is more shared
+   4. This behavior improves interoperability because there is more shared
       code between implementation
 
 5. Projects must have an open reference implementation


### PR DESCRIPTION
In chapter "Principles/4. Claiming OpenStack requiring use of
designated upstream code" the items 2 and 3 were duplicates,
removed item 3. Text were:
1. You are not OpenStack, if you pass all the tests but
   do not use the API framework
